### PR TITLE
feat: align names with upstream DTS

### DIFF
--- a/libqrc-udriver/src/qti_qrc_udriver.c
+++ b/libqrc-udriver/src/qti_qrc_udriver.c
@@ -37,9 +37,11 @@ typedef struct
 } model_info_t;
 
 model_info_t g_model_info_map[] = {
-  { "Robotics RB3gen2 addons vision mezz platform", "/dev/ttyHS2", "/dev/gpiochip4", 147 },
+  { "Robotics RB3gen2", "/dev/ttyHS2", "/dev/gpiochip4", 147 },
   { "IQ 9075 EVK", "/dev/ttyHS2", "/dev/gpiochip4", 129 },
+  { "Lemans", "/dev/ttyHS2", "/dev/gpiochip4", 129 },
   { "8275", "/dev/ttyHS2", "/dev/gpiochip2", 113 },
+  { "Monaco", "/dev/ttyHS2", "/dev/gpiochip2", 113 },
 };
 const int g_model_info_map_size = sizeof(g_model_info_map) / sizeof(g_model_info_map[0]);
 

--- a/libqrc/include/module/qrc_msg_management.h
+++ b/libqrc/include/module/qrc_msg_management.h
@@ -15,8 +15,6 @@
 extern "C" {
 #endif
 
-typedef void (*qrc_msg_cb)(struct qrc_pipe_s * pipe, void * data, size_t len, bool response);
-
 typedef struct qrc_pipe_s
 {
   char pipe_name[10];
@@ -28,6 +26,8 @@ typedef struct qrc_pipe_s
   bool pipe_ready;
   void (*cb)(struct qrc_pipe_s * pipe, void * data, size_t len, bool response);
 } qrc_pipe_s;
+
+typedef void (*qrc_msg_cb)(struct qrc_pipe_s * pipe, void * data, size_t len, bool response);
 
 enum qrc_write_status_e
 {


### PR DESCRIPTION
- Rename "Robotics RB3gen2" to match upstream DTS model name.
- Add mapping for Lemans.
- Add mapping for Monaco.
- Move qrc_msg_cb typedef after struct definition